### PR TITLE
fix image folder generation

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -2,6 +2,7 @@
 Test nexus2srs
 """
 
+import os
 from itertools import chain
 from hdfmap import list_files
 from nexus2srs import run_nexus2srs, set_logging_level
@@ -12,14 +13,16 @@ set_logging_level('info')
 # f = "example_files/782761.nxs"
 # f = "example_files/794932.nxs"
 # f = "example_files/815893.nxs"  # NXclassic_scan (eta)
-f = "example_files/879486.nxs"  # 2D scan
+# f = "example_files/879486.nxs"  # 2D scan
 # f = "example_files/i10-759799.nxs"
+f = "/dls/i16/data/2025/cm40634-8/1085744.nxs"
 
 # new = '%s_hdfmap.dat' % os.path.splitext(f)[0]
-# run_nexus2srs(f, new)
+new = f"example_files/{os.path.basename(f).replace('.nxs', '_check.dat')}"
+run_nexus2srs(f, new, '-tiff')
 
 # Multiple files
-files = list_files('example_files', '.nxs')
-dat_files = (f"{f[:-4]}_hdfmap.dat" for f in files)
-run_nexus2srs(*chain(*zip(files, dat_files)))
+# files = list_files('example_files', '.nxs')
+# dat_files = (f"{f[:-4]}_hdfmap.dat" for f in files)
+# run_nexus2srs(*chain(*zip(files, dat_files)))
 

--- a/tests/test_nexus2srs.py
+++ b/tests/test_nexus2srs.py
@@ -65,7 +65,7 @@ def test_nxs2dat_3d_i06():
         os.remove(new_file)
     nxs2dat(nexus_file, new_file, True)
     assert os.path.exists(new_file), "file conversion not completed"
-    assert os.path.exists(DATA_FOLDER + '/i06-353130-medipix-files/00001.tif'), "tif file writing imcomplete"
+    assert os.path.exists(DATA_FOLDER + '/i06-353130-medipix-files/00001.tif'), "tif file writing incomplete"
     # remove tif files
     shutil.rmtree(DATA_FOLDER + '/i06-353130-medipix-files')
     # Check dat file


### PR DESCRIPTION
Fix for issue #2

nexus2srs.py
 - nexus_detectors() now checks if a detector dataset has already been used and skips if it has. This stops the issue of creating multiple folders for the same data.
 - write_tiffs() now copies already existing TIFF images to the new dat file location, fixing the issue of broken template.